### PR TITLE
Optimize IconPicker: limit results and improve memory usage

### DIFF
--- a/src/Components/IconPicker.php
+++ b/src/Components/IconPicker.php
@@ -17,9 +17,29 @@ class IconPicker extends Select
     protected function setUp(): void
     {
         parent::setUp();
-        $this->searchable();
-        $this->options(Icon::query()->take(10)->pluck('label', 'name')->toArray());
-        $this->getSearchResultsUsing(fn (string $search): array => !empty($search) ? Icon::query()->where('name', 'like', "%{$search}%")->pluck('label', 'name')->toArray() : Icon::query()->limit(50)->pluck('label', 'name')->get()->toArray());
+
+        $this->options(fn () => Icon::query()
+            ->limit(20)
+            ->pluck('label', 'name')
+            ->toArray()
+        );
+
+        $this->getSearchResultsUsing(function (string $search): array {
+
+            if (empty($search)) {
+                return Icon::query()
+                    ->limit(50)
+                    ->pluck('label', 'name')
+                    ->toArray();
+            }
+
+            return Icon::query()
+                ->where('name', 'like', "%{$search}%")
+                ->limit(50)
+                ->pluck('label', 'name')
+                ->toArray();
+        });
+
         $this->allowHtml();
     }
 }


### PR DESCRIPTION
Problem

The current IconPicker loads all icons at once, leading to high memory usage and potential Allowed memory size exhausted errors.
Solution

    Limited initial icon load to 20 items.
    Restricted search results to a maximum of 50 items.
    Improved memory efficiency without changing the component's API.

This ensures better performance and resolves memory issues with large icon sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Icon Picker to display up to 20 icons in the options.
	- Improved search functionality to return up to 50 icons based on user input.

- **Bug Fixes**
	- Refined the logic for handling search results to improve clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->