### PR TITLE
fix: Icon not showing when not listed in limited by 50 options

### DIFF
--- a/src/Components/IconPicker.php
+++ b/src/Components/IconPicker.php
@@ -43,6 +43,9 @@ class IconPicker extends Select
                 ->toArray();
         });
 
+
+        $this->getOptionLabelUsing(fn ($state) => Icon::firstWhere('name', '=', $state)?->label);
+
         $this->allowHtml();
     }
 }


### PR DESCRIPTION
## Fix bug
When select a heroicon icon, after update, is not showing the icon preview. 

See:

Actual:
![image](https://github.com/user-attachments/assets/82d72d34-08bc-431b-8012-ad0019486554)
With PR
![preview of icone when added getOptionLabelUsing](https://github.com/user-attachments/assets/024c2712-47fa-452c-a7d7-a0bed20c465b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced icon picker with improved label retrieval method
  - Added capability to dynamically fetch icon labels based on icon name

<!-- end of auto-generated comment: release notes by coderabbit.ai -->